### PR TITLE
Added missing resources to follow VS2010/2017.

### DIFF
--- a/AppleWinExpress2013.vcxproj
+++ b/AppleWinExpress2013.vcxproj
@@ -236,6 +236,8 @@
     <None Include="resource\PRAVETS8M.ROM" />
     <None Include="resource\SSC.rom" />
     <None Include="resource\ThunderClockPlus.rom" />
+    <None Include="resource\TK3000e.rom" />
+    <None Include="resource\TKClock.rom" />
     <None Include="source\CPU\cpu_general.inl" />
     <None Include="source\CPU\cpu_instructions.inl" />
   </ItemGroup>
@@ -283,6 +285,7 @@
     <Image Include="resource\LED_CAPS_ON_LAT.BMP" />
     <Image Include="resource\LED_CAPS_ON_P8.BMP" />
     <Image Include="resource\RUN.BMP" />
+    <Image Include="resource\RUN3000E.bmp" />
     <Image Include="resource\RUNP.BMP" />
     <Image Include="resource\SETUP.BMP" />
   </ItemGroup>

--- a/AppleWinExpress2013.vcxproj.filters
+++ b/AppleWinExpress2013.vcxproj.filters
@@ -554,6 +554,9 @@
     <Image Include="resource\SETUP.BMP">
       <Filter>Resource Files</Filter>
     </Image>
+    <Image Include="resource\RUN3000E.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
   </ItemGroup>
   <ItemGroup>
     <None Include="resource\Apple2.rom">
@@ -605,6 +608,12 @@
       <Filter>Resource Files</Filter>
     </None>
     <None Include="resource\ThunderClockPlus.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\TK3000e.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\TKClock.rom">
       <Filter>Resource Files</Filter>
     </None>
   </ItemGroup>

--- a/AppleWinExpress2015.vcxproj
+++ b/AppleWinExpress2015.vcxproj
@@ -236,6 +236,8 @@
     <None Include="resource\PRAVETS8M.ROM" />
     <None Include="resource\SSC.rom" />
     <None Include="resource\ThunderClockPlus.rom" />
+    <None Include="resource\TK3000e.rom" />
+    <None Include="resource\TKClock.rom" />
     <None Include="source\CPU\cpu_general.inl" />
     <None Include="source\CPU\cpu_instructions.inl" />
   </ItemGroup>
@@ -283,6 +285,7 @@
     <Image Include="resource\LED_CAPS_ON_LAT.BMP" />
     <Image Include="resource\LED_CAPS_ON_P8.BMP" />
     <Image Include="resource\RUN.BMP" />
+    <Image Include="resource\RUN3000E.bmp" />
     <Image Include="resource\RUNP.BMP" />
     <Image Include="resource\SETUP.BMP" />
   </ItemGroup>

--- a/AppleWinExpress2015.vcxproj.filters
+++ b/AppleWinExpress2015.vcxproj.filters
@@ -554,6 +554,9 @@
     <Image Include="resource\SETUP.BMP">
       <Filter>Resource Files</Filter>
     </Image>
+    <Image Include="resource\RUN3000E.bmp">
+      <Filter>Resource Files</Filter>
+    </Image>
   </ItemGroup>
   <ItemGroup>
     <None Include="resource\Apple2.rom">
@@ -605,6 +608,12 @@
       <Filter>Resource Files</Filter>
     </None>
     <None Include="resource\ThunderClockPlus.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\TK3000e.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\TKClock.rom">
       <Filter>Resource Files</Filter>
     </None>
   </ItemGroup>


### PR DESCRIPTION
RUN3000E.bmp, TK3000e.rom and TKClock.rom are in VS2010/2017 projects but not in VS2013/2015 projects. Assuming they are required and so added to VS2013/2015 projects.